### PR TITLE
feat: query for currencies traded

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "bignumber.js": "^3.0.1",
     "five-bells-shared": "^21.0.1",
-    "lodash": "^4.17.2",
     "superagent": "^3.3.0"
   }
 }


### PR DESCRIPTION
now the backend will use the currencies from the config to determine the query sent to the API. this means it doesn't request extra data. also, some currencies (like BTC) were being left out of the allcurrencies query

resolves https://github.com/interledgerjs/ilp-connector-backend-yahoo/issues/2